### PR TITLE
Tabs missed some classes

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -2,11 +2,11 @@
   <div tabs>
     <ul :class="navStyleClass" role="tablist">
       <template v-for="header in headers">
-        <li v-if="header._isTab" :class="{active:header.active, disabled:header.disabled}" @click.prevent="select(header)">
-          <slot name="header"><a href="#" v-html="header.header"></a></slot>
+        <li v-if="header._isTab" class="nav-item" :class="{active:header.active, disabled:header.disabled}" @click.prevent="select(header)">
+          <slot name="header"><a href="#" class="nav-link" :class="{active:header.active}" v-html="header.header"></a></slot>
         </li>
         <dropdown v-if="header._isTabGroup" :text="header.header" :class="{active:header.active}" :disabled="header.disabled">
-          <li v-for="tab in header.tabs" :class="{disabled:tab.disabled}"><a href="#" @click.prevent="select(tab)">{{tab.header}}</a></li>
+          <li v-for="tab in header.tabs" class="nav-item" :class="{disabled:tab.disabled}"><a href="#" class="nav-link" :class="{active:header.active}" @click.prevent="select(tab)">{{tab.header}}</a></li>
         </dropdown>
       </template>
     </ul>


### PR DESCRIPTION
Tabs.vue template missed some bootstrap classes:

- `<li>` missed `class="nav-item”`
- `<a>` missed `class="nav-link”` and `:class="{active:header.active}”`