### PR TITLE
v-model expects input events to emit 'value' not 'event'

### DIFF
--- a/src/Input.vue
+++ b/src/Input.vue
@@ -176,7 +176,7 @@ export default {
       return ~['', null, undefined].indexOf(value) || value instanceof Function ? null : value
     },
     emit (e) {
-      this.$emit(e.type, e)
+      this.$emit(e.type, e.type == 'input' ? e.target.value : e)
       if (e.type === 'blur' && this.canValidate) { this.valid = this.validate() }
     },
     eval () {


### PR DESCRIPTION
To fix this bug https://github.com/yuche/vue-strap/issues/423

According to the vue docs v-model has changed to expect the value, not an object (as it previously was)

i have switched on the type='input' as to allow 'blur' events to exist as before

