### PR TITLE
Input: set options on mount to work with v-if

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -239,6 +239,9 @@ export default {
   },
   mounted () {
     if (this._parent) this._parent.children.push(this)
+    this.setOptions(this.options)
+    this.val = this.value
+    this.checkData()
   },
   beforeDestroy () {
     if (this._parent) {


### PR DESCRIPTION
When you have a \<select v-model="noLoadedYet"\> inside a \<div v-if="loaded"\> the select will parse the child \<option\> elements and build the values on CREATE even tho it is not mounted due to the v-if. Since the model hasnt been loaded yet (why the v-if exists), the checkData will notice that there is no value match to the data (doesnt exist yet), then it will null the value. This means that you cannot async load in data to the \<select\> without losing your initial value. 

Ive moved the setOptions & checkData to mounted to make it redo these steps once the data exists. (i didnt know if i should remove them from created)

Another option would be to remove the checkData value=null, as, when the data loads in (options watch) the setOptions is called, so they exist correctly, but the value is initial value is already lost.

