### PR TITLE
Fix occasional flash of the aside panel when it slides in

### DIFF
--- a/src/Aside.vue
+++ b/src/Aside.vue
@@ -107,6 +107,9 @@ export default {
   right: 0;
 }
 .slideleft-enter {
+  transform:translateX(-100%);
+}
+.slideleft-enter-active {
   animation:slideleft-in .3s;
 }
 .slideleft-leave-active {


### PR DESCRIPTION
Fixes two issues:

1) Setting the animation on .slideleft-enter doesn't seem to work. According to Vue docs this class is applied for one frame and then removed so perhaps that is the reason.

2) If we use "enter-active" transition class, there is an occasional glitch where the nav flashes at translateX(0) briefly before sliding in. I presume because for one frame, the panel appears at default translateX(0). The suggested change removes the glitch by setting the panel off screen before it is switched on (ie. applied before element is insterted).