### PR TITLE
Fix change event for select with multiple

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -178,12 +178,13 @@ export default {
     },
     select (v) {
       if (this.val instanceof Array) {
-        if (~this.val.indexOf(v)) {
-          var index = this.val.indexOf(v)
-          this.val.splice(index, 1)
+        var newVal = this.val.slice(0)
+        if (~newVal.indexOf(v)) {
+          newVal.splice(newVal.indexOf(v), 1)
         } else {
-          this.val.push(v)
+          newVal.push(v)
         }
+        this.val = newVal
         if (this.closeOnSelect) {
           this.toggle()
         }


### PR DESCRIPTION
The `change` and `input` events didn't trigger because the old and new
value in the `val` watcher always ended up being identical. Fixing this
by cloning `val` before modifying it.

Let me know if you prefer PRs on another branch or fork, I wasn't really sure where to submit it :)