### PR TITLE
Fix for zero index javascript dates

### DIFF
--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -233,7 +233,7 @@ export default {
     parse (str = this.value) {
       let date
       if (str.length === 10 && (this.format === 'dd-MM-yyyy' || this.format === 'dd/MM/yyyy')) {
-        date = new Date(str.substring(6, 10), str.substring(3, 5), str.substring(0, 2))
+        date = new Date(str.substring(6, 10), str.substring(3, 5)-1, str.substring(0, 2))
       } else {
         date = new Date(str)
       }


### PR DESCRIPTION
JS's dates are zero indexed so the datepicker component should honour this but at the same time make it easier for developers to select the date they want. It's unlikely users will be passing a month of 03 that should match April, it should instead match March.