### PR TITLE
Add callback to be run when the modal is displayed.

### DIFF
--- a/docs/example/modalDocs.vue
+++ b/docs/example/modalDocs.vue
@@ -118,6 +118,12 @@
       <p>A callback Function when you click the modal primary button.</p>
     </div>
     <div>
+      <p>showCallback</p>
+      <p><code>Function</code></p>
+      <p></p>
+      <p>A callback function that will be run every time the modal is displayed.</p>
+    </div>
+    <div>
       <p>cancel-text</p>
       <p><code>String</code></p>
       <p>Close</p>

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -27,6 +27,7 @@ export default {
   props: {
     backdrop: {type: Boolean, default: true},
     callback: {type: Function, default: null},
+    showCallback: {type: Function, default: null},
     cancelText: {type: String, default: 'Close'},
     effect: {type: String, default: null},
     large: {type: Boolean, default: false},
@@ -85,6 +86,8 @@ export default {
         const body = document.body
         body.style.paddingRight = null
         body.classList.remove('modal-open')
+      } else {
+        if (this.showCallback instanceof Function) this.showCallback()
       }
     }
   }


### PR DESCRIPTION
This adds a new `showCallback` property to the `Modal` component.  If set, the callback is run every time the modal is displayed.

This is a pretty small change, but I haven't run any tests other than checking that it works in my use case.  `npm run build` succeeds, but `npm run docs` fails with what looks like an unrelated error.