### PR TITLE
Update Select.vue to handle undefined button case

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -207,7 +207,7 @@ export default {
       this.$emit('options', this.list)
     },
     toggle () {
-      if (this.disabled && !this.show) return;
+      if ((this.disabled && !this.show) || !this.$refs.btn) return;
       this.show = !this.show
       if (!this.show) this.$refs.btn.focus()
     },


### PR DESCRIPTION
When the X button has been pressed on the select element then the select component itself is no longer visible for whatever reason, the `$refs.btn` is `undefined`. Check for this to avoid `Uncaught TypeError: Cannot read property 'focus' of undefined`.

Note: The use case in this instance for me is having the select component in a tab, when the X is pressed, I change tab thus removing the select component from scope.